### PR TITLE
Add database health checks

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -191,7 +191,7 @@ func main() {
 	log.Info().Msg("WebSocket hub started")
 
 	// Create handlers
-	h := handlers.NewHandlers(svc, hub)
+	h := handlers.NewHandlers(svc, hub, db)
 	log.Info().Msg("Handlers initialized")
 
 	// Setup routes

--- a/backend/internal/handlers/auth_integration_test.go
+++ b/backend/internal/handlers/auth_integration_test.go
@@ -40,7 +40,7 @@ func TestAuthFlow_Integration(t *testing.T) {
 	}
 
 	// Create handlers and setup routes
-	h := handlers.NewHandlers(svc, nil)
+	h := handlers.NewHandlers(svc, nil, ctx.DB)
 
 	router := mux.NewRouter()
 	api := router.PathPrefix("/api/v1").Subrouter()
@@ -354,7 +354,7 @@ func TestPasswordValidation_Integration(t *testing.T) {
 		JWTManager:    ctx.JWTManager,
 	}
 
-	h := handlers.NewHandlers(svc, nil)
+	h := handlers.NewHandlers(svc, nil, ctx.DB)
 
 	router := mux.NewRouter()
 	api := router.PathPrefix("/api/v1").Subrouter()

--- a/backend/internal/handlers/character_integration_test.go
+++ b/backend/internal/handlers/character_integration_test.go
@@ -111,7 +111,7 @@ func setupIntegrationTest(t *testing.T) (*testContext, func()) {
 
 	// Create handlers
 	hub := websocket.GetHub()
-	handlers := NewHandlers(svc, hub)
+       handlers := NewHandlers(svc, hub, db)
 
 	// Setup router
 	router := mux.NewRouter()

--- a/backend/internal/handlers/combat_integration_test.go
+++ b/backend/internal/handlers/combat_integration_test.go
@@ -53,7 +53,7 @@ func TestCombatFlow_Integration(t *testing.T) {
 	go hub.Run()
 
 	// Create handlers and setup routes
-	h := handlers.NewHandlers(svc, hub)
+	h := handlers.NewHandlers(svc, hub, ctx.DB)
 
 	router := mux.NewRouter()
 	api := router.PathPrefix("/api/v1").Subrouter()
@@ -376,7 +376,7 @@ func TestCombatAuthorization_Integration(t *testing.T) {
 		JWTManager:   ctx.JWTManager,
 	}
 
-	h := handlers.NewHandlers(svc, nil)
+	h := handlers.NewHandlers(svc, nil, ctx.DB)
 
 	router := mux.NewRouter()
 	api := router.PathPrefix("/api/v1").Subrouter()

--- a/backend/internal/handlers/game_security_test.go
+++ b/backend/internal/handlers/game_security_test.go
@@ -41,7 +41,7 @@ func TestGameSessionSecurity(t *testing.T) {
 	}
 
 	// Create handlers
-	h := handlers.NewHandlers(svc, nil)
+	h := handlers.NewHandlers(svc, nil, testCtx.DB)
 
 	// Create test users
 	dm := createTestUser(t, testCtx, "dm_user", "dm@example.com", "dm")

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/your-username/dnd-game/backend/internal/auth"
+	"github.com/your-username/dnd-game/backend/internal/database"
 	"github.com/your-username/dnd-game/backend/internal/services"
 	"github.com/your-username/dnd-game/backend/internal/websocket"
 	"github.com/your-username/dnd-game/backend/pkg/errors"
@@ -28,10 +29,11 @@ type Handlers struct {
 	jwtManager          *auth.JWTManager
 	refreshTokenService *services.RefreshTokenService
 	websocketHub        *websocket.Hub
+	db                  *database.DB
 }
 
 // NewHandlers creates a new handlers instance
-func NewHandlers(svc *services.Services, hub *websocket.Hub) *Handlers {
+func NewHandlers(svc *services.Services, hub *websocket.Hub, db *database.DB) *Handlers {
 	return &Handlers{
 		userService:         svc.Users,
 		characterService:    svc.Characters,
@@ -49,6 +51,7 @@ func NewHandlers(svc *services.Services, hub *websocket.Hub) *Handlers {
 		jwtManager:          svc.JWTManager,
 		refreshTokenService: svc.RefreshTokens,
 		websocketHub:        hub,
+		db:                  db,
 	}
 }
 

--- a/backend/internal/handlers/health_new.go
+++ b/backend/internal/handlers/health_new.go
@@ -99,23 +99,18 @@ func (h *Handlers) ReadinessProbe(w http.ResponseWriter, r *http.Request) {
 	checks := make(map[string]HealthCheckResult)
 	allHealthy := true
 
-	// TODO: Check database connection if available
-	// This would require adding a GetDB() method to repositories or passing DB separately
-	/*
-		if db, ok := h.repositories.(*sql.DB); ok && db != nil {
-			if err := db.Ping(); err != nil {
-				checks["database"] = HealthCheckResult{
-					Status:  "unhealthy",
-					Message: "Database connection failed",
-				}
-				allHealthy = false
-			} else {
-				checks["database"] = HealthCheckResult{
-					Status: "healthy",
-				}
+	// Check database connection if available
+	if h.db != nil {
+		if err := h.db.Ping(); err != nil {
+			checks["database"] = HealthCheckResult{
+				Status:  "unhealthy",
+				Message: "Database connection failed",
 			}
+			allHealthy = false
+		} else {
+			checks["database"] = HealthCheckResult{Status: "healthy"}
 		}
-	*/
+	}
 
 	// Check if we have required services
 	if h.userService == nil || h.characterService == nil {
@@ -176,10 +171,15 @@ func (h *Handlers) DetailedHealth(w http.ResponseWriter, r *http.Request) {
 	checks := make(map[string]HealthCheckResult)
 
 	// Check database if available
-	// TODO: Add database health check when repository interface supports it
-	checks["database"] = HealthCheckResult{
-		Status:  "healthy",
-		Message: "Database check not implemented",
+	if h.db != nil {
+		if err := h.db.Ping(); err != nil {
+			checks["database"] = HealthCheckResult{
+				Status:  "unhealthy",
+				Message: "Database connection failed",
+			}
+		} else {
+			checks["database"] = HealthCheckResult{Status: "healthy"}
+		}
 	}
 
 	// Check services

--- a/backend/internal/handlers/test_helpers.go
+++ b/backend/internal/handlers/test_helpers.go
@@ -106,7 +106,7 @@ func SetupTestHandlers(t *testing.T, testCtx *testutil.IntegrationTestContext) (
 	}
 
 	// Create handlers
-	h := NewHandlers(svc, hub)
+	h := NewHandlers(svc, hub, testCtx.DB)
 
 	return h, hub
 }


### PR DESCRIPTION
## Summary
- inject database connection into handlers
- check database connectivity in health endpoints
- pass DB when creating handlers in server and tests

## Testing
- `go test ./backend/internal/handlers -run TestHealthCheckIntegration -count=1`
- `go test ./backend/internal/handlers/...` *(fails: websocket upgrade error)*

------
https://chatgpt.com/codex/tasks/task_e_684a4258a3f8832fba580ab7e14a4693